### PR TITLE
[wgpu] レンダーパイプラインのキャッシュ機能を追加

### DIFF
--- a/gfx-wgpu/Cargo.toml
+++ b/gfx-wgpu/Cargo.toml
@@ -13,6 +13,7 @@ raw-window-handle = "0.4.0"
 spirv-reflect = "0.2.3"
 winit = "0.26.0"
 bytemuck = { version = "*", features = ["derive"] }
+uuid = { version = "0.8.0", features = ["v4"] }
 
 [dev-dependencies]
 sjgfx-util = { path = "../gfx-util" }

--- a/gfx-wgpu/src/shader_wgpu.rs
+++ b/gfx-wgpu/src/shader_wgpu.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use sjgfx_interface::{IShader, ShaderInfo};
+use uuid::Uuid;
 use wgpu::ComputePipelineDescriptor;
 
 use crate::DeviceWgpu;
@@ -20,6 +21,10 @@ impl ShaderWgpu {
                 info.get_pixel_shader_binary().as_ref().unwrap(),
             );
         }
+    }
+
+    pub fn id(&self) -> &Uuid {
+        &self.shader_data.id
     }
 
     pub fn view(&self) -> ShaderView {
@@ -69,6 +74,7 @@ impl ShaderWgpu {
                 vertex_attributes: None,
                 bind_group_layout: Arc::new(bind_group_layout),
                 pipeline_layout: Arc::new(pipeline_layout),
+                id: Uuid::new_v4(),
             },
         }
     }
@@ -116,6 +122,7 @@ impl ShaderWgpu {
                 vertex_attributes: Some(Arc::new(vertex_attributes)),
                 bind_group_layout: Arc::new(bind_group_layout),
                 pipeline_layout: Arc::new(pipeline_layout),
+                id: Uuid::new_v4(),
             },
         }
     }
@@ -498,6 +505,10 @@ impl ShaderView {
     pub fn get_compute_pipeline(&self) -> &wgpu::ComputePipeline {
         self.shader_data.compute_pipeline.as_ref().unwrap()
     }
+
+    pub fn get_id(&self) -> &Uuid {
+        &self.shader_data.id
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -510,6 +521,7 @@ struct ShaderData {
     pub vertex_attributes: Option<Arc<Vec<wgpu::VertexAttribute>>>,
     pub bind_group_layout: Arc<wgpu::BindGroupLayout>,
     pub pipeline_layout: Arc<wgpu::PipelineLayout>,
+    pub id: Uuid,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
レンダリングパイプラインの構築に必要なのはレンダーターゲットとシェーダ
ひとまずシェーダが変わったらレンダーパイプラインを作り直すようにした
旧実装では毎フレームレンダーターゲットを作り直してた

wave の CPU 使用率が 16% -> 10% くらい削減 on MacBook Air