### PR TITLE
vi-rs への依存を削減

### DIFF
--- a/gfx-interface/Cargo.toml
+++ b/gfx-interface/Cargo.toml
@@ -7,4 +7,3 @@ version = "0.1.0"
 winit = "0.26.0"
 bitflags ="1.3.2"
 raw-window-handle = "0.4.0"
-sjvi = { path = "../vi-rs" }

--- a/gfx-interface/src/device_api.rs
+++ b/gfx-interface/src/device_api.rs
@@ -1,4 +1,4 @@
-use sjvi::IDisplay;
+use crate::IDisplay;
 
 use crate::enums::DebugMode;
 

--- a/gfx-interface/src/display_api.rs
+++ b/gfx-interface/src/display_api.rs
@@ -1,0 +1,11 @@
+pub trait IDisplay {
+    fn is_redraw_requested(&self) -> bool;
+
+    fn listen<TListener: IDisplayEventListener>(&self, listener: &mut TListener);
+
+    fn get_scale_factor(&self) -> f64;
+}
+
+pub trait IDisplayEventListener {
+    fn on_resized(&mut self, _width: u32, _height: u32) {}
+}

--- a/gfx-interface/src/lib.rs
+++ b/gfx-interface/src/lib.rs
@@ -3,6 +3,7 @@ mod color_target_view_api;
 mod command_buffer_api;
 mod depth_stencil_view_api;
 mod device_api;
+mod display_api;
 mod enums;
 mod fence_api;
 mod queue_api;
@@ -20,6 +21,7 @@ pub use color_target_view_api::{ColorTargetViewInfo, IColorTargetView};
 pub use command_buffer_api::{CommandBufferInfo, ICommandBuffer};
 pub use depth_stencil_view_api::{DepthStencilStateInfo, IDepthStencilView};
 pub use device_api::{DeviceInfo, IDevice};
+pub use display_api::{IDisplay, IDisplayEventListener};
 pub use enums::{
     AttributeFormat, DebugMode, GpuAccess, ImageFormat, IndexFormat, PrimitiveTopology, ShaderStage,
 };

--- a/gfx-interface/src/swap_chain_api.rs
+++ b/gfx-interface/src/swap_chain_api.rs
@@ -1,4 +1,4 @@
-use sjvi::IDisplayEventListener;
+use crate::IDisplayEventListener;
 
 pub struct SwapChainInfo {
     width: u32,

--- a/gfx-wgpu/src/swap_chain_wgpu.rs
+++ b/gfx-wgpu/src/swap_chain_wgpu.rs
@@ -1,7 +1,6 @@
 use std::sync::{Arc, Mutex};
 
-use sjgfx_interface::{ISwapChain, SwapChainInfo};
-use sjvi::IDisplayEventListener;
+use sjgfx_interface::{IDisplayEventListener, ISwapChain, SwapChainInfo};
 use wgpu::{SurfaceTexture, TextureFormat};
 
 use crate::{

--- a/vi-rs/Cargo.toml
+++ b/vi-rs/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 web-sys = { version = "0.3.58", features=[ "GpuBuffer", "HtmlCanvasElement", "WebGl2RenderingContext", "Window", "Document"] }
 wasm-bindgen = { version = "0.2" }
 winit = "0.26.1"
+sjgfx-interface = { path = "../gfx-interface" }
 
 [target.'cfg(not(any(target_arch = "wasm32")))'.dependencies]
 glutin = "*"

--- a/vi-rs/src/lib.rs
+++ b/vi-rs/src/lib.rs
@@ -4,10 +4,7 @@
 pub mod winit;
 
 pub mod web_sys;
-
-pub trait IDisplayEventListener {
-    fn on_resized(&mut self, _width: u32, _height: u32) {}
-}
+use sjgfx_interface::IDisplay;
 
 pub trait IInstance {
     type DisplayId: Eq + PartialEq + Clone;
@@ -20,14 +17,6 @@ pub trait IInstance {
     fn try_get_display(&self, id: &Self::DisplayId) -> Option<&Self::Display>;
 
     fn try_update(&mut self) -> bool;
-}
-
-pub trait IDisplay {
-    fn is_redraw_requested(&self) -> bool;
-
-    fn listen<TListener: IDisplayEventListener>(&self, listener: &mut TListener);
-
-    fn get_scale_factor(&self) -> f64;
 }
 
 #[cfg(test)]

--- a/vi-rs/src/web_sys/mod.rs
+++ b/vi-rs/src/web_sys/mod.rs
@@ -2,7 +2,8 @@ use std::{collections::HashMap, sync::Arc};
 
 use wasm_bindgen::JsCast;
 
-use crate::{IDisplay, IDisplayEventListener, IInstance};
+use crate::IInstance;
+use sjgfx_interface::{IDisplay, IDisplayEventListener};
 
 pub struct Instance {
     display_table: HashMap<DisplayId, Display>,

--- a/vi-rs/src/winit/mod.rs
+++ b/vi-rs/src/winit/mod.rs
@@ -12,7 +12,8 @@ use winit::{
     window::{Window, WindowBuilder},
 };
 
-use crate::{IDisplay, IDisplayEventListener, IInstance};
+use crate::IInstance;
+use sjgfx_interface::{IDisplay, IDisplayEventListener};
 
 pub enum MouseEvent {
     Pressed(f64, f64, MouseButton),


### PR DESCRIPTION
vi-rs で定義していた trait を interface に移動
vi-rs に依存するクレートを最小限に