### PR TITLE
[vk] 生ハンドルからデバイスを生成する関数を追加

### DIFF
--- a/gfx-vulkano/examples/hello_triangle_vk.rs
+++ b/gfx-vulkano/examples/hello_triangle_vk.rs
@@ -12,11 +12,13 @@ use winit::{
     event::{Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
     platform::run_return::EventLoopExtRunReturn,
+    window::WindowBuilder,
 };
 
 fn main() {
     let mut event_loop = EventLoop::new();
-    let device = DeviceVk::new_as_graphics(&DeviceInfo::new(), &event_loop);
+    let window = WindowBuilder::new().build(&event_loop).unwrap();
+    let device = DeviceVk::new_from_handle(&DeviceInfo::new(), &window);
     let mut swap_chain = SwapChainVk::new(&device, &SwapChainInfo::new());
     let mut command_buffer = CommandBufferVk::new(&device, &CommandBufferInfo::new());
     let mut queue = QueueVk::new(&device, &QueueInfo::new());


### PR DESCRIPTION
ウィンドウハンドルを生成するロジックを抽象化
特定のクレートに依存しないように修正