### PR TITLE
[wgpu] 定数バッファのサイズ設定が間違ってる不具合を修正

### DIFF
--- a/gfx-wgpu/src/shader_wgpu.rs
+++ b/gfx-wgpu/src/shader_wgpu.rs
@@ -171,7 +171,7 @@ impl ShaderWgpu {
                     ty: wgpu::BindingType::Buffer {
                         ty: wgpu::BufferBindingType::Uniform,
                         has_dynamic_offset: false,
-                        min_binding_size: wgpu::BufferSize::new(64 as u64),
+                        min_binding_size: wgpu::BufferSize::new(x.size as u64),
                     },
                     count: None,
                 };


### PR DESCRIPTION
デバッグ用のコードをコミットしていた。
ちゃんとリフレクションの結果から構築するよう修正