### PR TITLE
[vk] Windows 版で Vulkan のサンプルが起動しない不具合を修正

### DIFF
--- a/gfx-vulkano/examples/hello_triangle_vk.rs
+++ b/gfx-vulkano/examples/hello_triangle_vk.rs
@@ -9,6 +9,7 @@ use sjgfx_vulkano::{
     ViewportScissorStateVk,
 };
 use winit::{
+    dpi::PhysicalSize,
     event::{Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
     platform::run_return::EventLoopExtRunReturn,
@@ -17,7 +18,10 @@ use winit::{
 
 fn main() {
     let mut event_loop = EventLoop::new();
-    let window = WindowBuilder::new().build(&event_loop).unwrap();
+    let window = WindowBuilder::new()
+        .with_inner_size(PhysicalSize::new(1280, 960))
+        .build(&event_loop)
+        .unwrap();
     let device = DeviceVk::new_from_handle(&DeviceInfo::new(), &window);
     let mut swap_chain = SwapChainVk::new(&device, &SwapChainInfo::new());
     let mut command_buffer = CommandBufferVk::new(&device, &CommandBufferInfo::new());

--- a/gfx-vulkano/src/swap_chain_vk.rs
+++ b/gfx-vulkano/src/swap_chain_vk.rs
@@ -41,7 +41,7 @@ impl SwapChainVk {
                 min_image_count: capabilities.min_image_count,
                 image_format: Some(image_format),
                 // image_extent: surface.window().inner_size().into(),
-                image_extent: [640, 480],
+                image_extent: [1280, 960],
                 image_usage: ImageUsage::COLOR_ATTACHMENT,
                 composite_alpha: CompositeAlpha::Opaque,
                 ..Default::default()


### PR DESCRIPTION
SwapChain のサイズとウィンドウサイズが一致してないとダメらしい
本来は動的に判定すべきだが、ひとまず固定値でエラーを回避