### PR TITLE
演算シェーダーの SPIR-V が正しく生成されるよう修正

### DIFF
--- a/gfx-util/Cargo.toml
+++ b/gfx-util/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 [dependencies]
 sjgfx-interface = { path = "../gfx-interface" }
 tobj = "3.2.1"
-naga = { version = "0.12.2", features = ["glsl-in", "spv-out", "wgsl-out"] }
+naga = { version = "0.12.2", features = ["glsl-in", "wgsl-in", "spv-out", "wgsl-out", "hlsl-out"] }
 
 # rspirv-0.11.0+1.5.4
 rspirv = { git = "https://github.com/gfx-rs/rspirv.git", rev = "c7305b8" }

--- a/gfx-util/examples/glsl_to_hlsl.rs
+++ b/gfx-util/examples/glsl_to_hlsl.rs
@@ -1,0 +1,23 @@
+use sjgfx_util::{Glsl, Hlsl, SpirV};
+use sjgfx_util::{ShaderConverter, Wgsl};
+
+fn main() {
+    let source = "#version 450
+
+    layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
+
+    layout(set = 0, binding = 0) buffer Data {
+        uint u_Data[];
+    };
+
+    void main()
+    {
+        uint index = gl_GlobalInvocationID.x;
+        u_Data[index] = index;
+    }
+";
+    let wglsl = ShaderConverter::<Wgsl, Glsl>::convert_glsl_to_wgsl(&source);
+    println!("{}", wglsl);
+
+    let _data = ShaderConverter::<SpirV, Wgsl>::convert_wgsl_to_spirv(&wglsl);
+}

--- a/gfx-util/src/lib.rs
+++ b/gfx-util/src/lib.rs
@@ -1,7 +1,9 @@
 mod shader_compiler;
+mod shader_converter;
 mod shader_reflection;
 
 pub use shader_compiler::{ShaderCompiler, ShaderStage};
+pub use shader_converter::{Glsl, Hlsl, ShaderConverter, SpirV, Wgsl};
 pub use shader_reflection::ShaderReflection;
 
 use sjgfx_interface::{BufferInfo, GpuAccess, IBuffer, IDevice};

--- a/gfx-util/src/shader_converter.rs
+++ b/gfx-util/src/shader_converter.rs
@@ -1,0 +1,88 @@
+use core::fmt;
+
+pub struct Hlsl;
+pub struct Glsl;
+pub struct SpirV;
+pub struct Wgsl;
+
+pub struct ShaderConverter<TDst, TSrc> {
+    _marker: std::marker::PhantomData<(TDst, TSrc)>,
+}
+
+impl ShaderConverter<Hlsl, Glsl> {
+    pub fn convert_glsl_to_hlsl(source: &str) {
+        let stage = naga::ShaderStage::Compute;
+        let options = naga::front::glsl::Options::from(stage);
+        let module = naga::front::glsl::Frontend::default()
+            .parse(&options, source)
+            .unwrap();
+
+        let info = naga::valid::Validator::new(
+            naga::valid::ValidationFlags::all(),
+            naga::valid::Capabilities::all(),
+        )
+        .validate(&module)
+        .unwrap();
+
+        let options = naga::back::hlsl::Options::default();
+        let mut data = naga::back::hlsl::Writer::new(A {}, &options);
+        data.write(&module, &info).unwrap();
+    }
+}
+
+impl ShaderConverter<Wgsl, Glsl> {
+    pub fn convert_glsl_to_wgsl(source: &str) -> String {
+        let stage = naga::ShaderStage::Compute;
+        let options = naga::front::glsl::Options::from(stage);
+        let module = naga::front::glsl::Frontend::default()
+            .parse(&options, source)
+            .unwrap();
+
+        let info = naga::valid::Validator::new(
+            naga::valid::ValidationFlags::all(),
+            naga::valid::Capabilities::all(),
+        )
+        .validate(&module)
+        .unwrap();
+
+        let flags = naga::back::wgsl::WriterFlags::all();
+        naga::back::wgsl::write_string(&module, &info, flags).unwrap()
+    }
+}
+
+impl ShaderConverter<SpirV, Wgsl> {
+    pub fn convert_wgsl_to_spirv(source: &str) -> Vec<u8> {
+        let module = naga::front::wgsl::parse_str(source).unwrap();
+        let info = naga::valid::Validator::new(
+            naga::valid::ValidationFlags::all(),
+            naga::valid::Capabilities::all(),
+        )
+        .validate(&module)
+        .unwrap();
+
+        let options = naga::back::spv::Options::default();
+        let mut data = naga::back::spv::write_vec(&module, &info, &options, None).unwrap();
+
+        let ratio = std::mem::size_of::<u32>() / std::mem::size_of::<u8>();
+        let length = data.len() * ratio;
+        let capacity = data.capacity() * ratio;
+        let ptr = data.as_mut_ptr() as *mut u8;
+        unsafe {
+            let u8_data: Vec<u8> = Vec::from_raw_parts(ptr, length, capacity).clone();
+
+            // 元データが 2 重に破棄されないように、元データを破棄しないようにする
+            std::mem::forget(data);
+
+            u8_data
+        }
+    }
+}
+
+// GLSL -> HLSL の変換結果を出力するために必要なやつ
+struct A;
+impl fmt::Write for A {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        print!("{}", s);
+        fmt::Result::Ok(())
+    }
+}


### PR DESCRIPTION
GLSL -> SPIR-V だと Vulkano で実行できないバイナリが出力される
GLSL -> WGSL -> SPIR-V と 2 段がまえで変換してしのぐ